### PR TITLE
Add sharness tests

### DIFF
--- a/tests/sharness/.gitignore
+++ b/tests/sharness/.gitignore
@@ -1,0 +1,3 @@
+lib/sharness/
+test-results/
+trash directory.*.sh/

--- a/tests/sharness/Makefile
+++ b/tests/sharness/Makefile
@@ -1,0 +1,67 @@
+# Run sharness tests
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+# NOTE: run with TEST_VERBOSE=1 for verbose sharness tests.
+
+T = $(sort $(wildcard t[0-9][0-9][0-9][0-9]-*.sh))
+LIBDIR = lib
+SHARNESSDIR = sharness
+AGGREGATE = $(LIBDIR)/$(SHARNESSDIR)/aggregate-results.sh
+
+
+# Add below the binaries that this project generates or needs.
+# For example:
+# BINS = bin/ipfs
+BINS =
+
+all: aggregate
+
+clean: clean-test-results
+	@echo "*** $@ ***"
+	# Clean binaries below.
+	# For example:
+	# -rm -rf bin/ipfs
+
+clean-test-results:
+	@echo "*** $@ ***"
+	-rm -rf test-results
+
+$(T): clean-test-results deps
+	@echo "*** $@ ***"
+	./$@
+
+aggregate: clean-test-results $(T)
+	@echo "*** $@ ***"
+	ls test-results/t*-*.sh.*.counts | $(AGGREGATE)
+
+# Add below some needed dependencies.
+# For example:
+# deps: sharness $(BINS) curl
+deps: sharness $(BINS)
+
+sharness:
+	@echo "*** checking $@ ***"
+	lib/install-sharness.sh
+
+# Add below other targets like:
+# - the targets needed to build binaries,
+# - targets using special compile flags,
+# - targets to check or install dependencies.
+#
+# For example:
+#
+# GOFLAGS =
+#
+# bin/%: FORCE
+# 	cd .. && make GOFLAGS=$(GOFLAGS) $@
+#
+# race:
+# 	make GOFLAGS=-race all
+#
+# curl:
+#	@which curl >/dev/null || (echo "Please install curl!" && false)
+
+.PHONY: all clean clean-test-results $(T) aggregate deps sharness FORCE
+

--- a/tests/sharness/lib/install-sharness.sh
+++ b/tests/sharness/lib/install-sharness.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# install-sharness.sh
+#
+# Copyright (c) 2014 Juan Batiz-Benet
+# Copyright (c) 2015 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+# This script checks that Sharness is installed in:
+#
+# $(pwd)/$clonedir/$sharnessdir/
+#
+# where $clonedir and $sharnessdir are configured below.
+#
+# If Sharness is not installed, this script will clone it
+# from $urlprefix (defined below).
+#
+# If Sharness is not uptodate with $version (defined below),
+# this script will fetch and will update the installed
+# version to $version.
+#
+
+# settings
+version=2298d6a491f43da26a89175173b6b56edd4313dd
+urlprefix=https://github.com/mlafeldt/sharness.git
+clonedir=lib
+sharnessdir=sharness
+
+if test -f "$clonedir/$sharnessdir/SHARNESS_VERSION_$version"
+then
+    # There is the right version file. Great, we are done!
+    exit 0
+fi
+
+die() {
+    echo >&2 "$@"
+    exit 1
+}
+
+checkout_version() {
+    git checkout "$version" || die "Could not checkout '$version'"
+    rm -f SHARNESS_VERSION_* || die "Could not remove 'SHARNESS_VERSION_*'"
+    touch "SHARNESS_VERSION_$version" || die "Could not create 'SHARNESS_VERSION_$version'"
+    echo "Sharness version $version is checked out!"
+}
+
+if test -d "$clonedir/$sharnessdir/.git"
+then
+    # We need to update sharness!
+    cd "$clonedir/$sharnessdir" || die "Could not cd into '$clonedir/$sharnessdir' directory"
+    git fetch || die "Could not fetch to update sharness"
+else
+    # We need to clone sharness!
+    mkdir -p "$clonedir" || die "Could not create '$clonedir' directory"
+    cd "$clonedir" || die "Could not cd into '$clonedir' directory"
+
+    git clone "$urlprefix" || die "Could not clone '$urlprefix'"
+    cd "$sharnessdir" || die "Could not cd into '$sharnessdir' directory"
+fi
+
+checkout_version

--- a/tests/sharness/t0000-sharness.sh
+++ b/tests/sharness/t0000-sharness.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+test_description="Show basic features of Sharness"
+
+. ./lib/sharness/sharness.sh
+
+test_expect_success "Success is reported like this" "
+    echo hello world | grep hello
+"
+
+test_expect_success "Commands are chained this way" "
+    test x = 'x' &&
+    test 2 -gt 1 &&
+    echo success
+"
+
+return_42() {
+    echo "Will return soon"
+    return 42
+}
+
+test_expect_success "You can test for a specific exit code" "
+    test_expect_code 42 return_42
+"
+
+test_expect_failure "We expect this to fail" "
+    test 1 = 2
+"
+
+test_done
+
+# vi: set ft=sh :

--- a/tests/sharness/t0010-multihash-basics.sh
+++ b/tests/sharness/t0010-multihash-basics.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+test_description="Test multihash basics"
+
+. ./lib/sharness/sharness.sh
+
+test_expect_success "current dir is writable" '
+	echo "It works!" >test.txt
+'
+
+test_expect_success "multihash is available" '
+	type multihash
+'
+
+test_expect_success "'multihash --help' looks good" '
+	multihash --help >actual 2>&1 || true &&
+	egrep -i "usage" actual >/dev/null
+'
+
+for opt in algorithm check encoding length quiet help
+do 
+	test_expect_success "'multihash --help' mention -$opt option" '
+		egrep "[-]$opt" actual >/dev/null
+	'
+done
+
+test_expect_success "'multihash test.txt' works" '
+	multihash test.txt >actual
+'
+
+test_expect_success "'multihash test.txt' output looks good" '
+	echo "QmTwovvskpD1hzuJA8wLA73wjxSisrVknKeNvGZVyjDguU" >expected &&
+	test_cmp expected actual
+'
+
+test_done
+
+# vi: set ft=sh :


### PR DESCRIPTION
This is sharness support and a few basic tests to start a Standard Implementation Test Suite as discussed in issue #32.

go-multihash does not fully pass it for now because of things discussed in https://github.com/jbenet/go-multihash/issues/18.